### PR TITLE
Add initializer which reads the private key from a file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Use this private key together with the issuer ID and the private key ID to creat
 let configuration = APIConfiguration(issuerID: "<YOUR ISSUER ID>", privateKeyID: "<YOUR PRIVATE KEY ID>", privateKey: "<YOUR PRIVATE KEY>")
 ```
 
+Alternatively you can pass the path to the .p8 file:
+
+```swift
+let configuration = APIConfiguration(issuerID: "<YOUR ISSUER ID>", privateKeyID: "<YOUR PRIVATE KEY ID>", privateKeyURL: URL(fileURLWithPath: "~/AuthKey_<YOUR PRIVATE KEY ID>.p8"))
+```
+
+You can even omit the `privateKeyID` as it can be inferred from the name of the .p8 file.
+
 #### 3. Create an APIProvider and perform a request
 After creating an `APIProvider` instance with your `APIConfiguration` you can start performing your first request.
 

--- a/Sources/APIProvider.swift
+++ b/Sources/APIProvider.swift
@@ -47,6 +47,28 @@ public struct APIConfiguration {
             throw JWT.Error.invalidPrivateKey
         }
     }
+    
+    /// Creates a new API configuration to use for initialising the API Provider.
+    ///
+    /// - Parameters:
+    ///   - issuerID: Your issuer ID from the API Keys page in App Store Connect (Ex: 57246542-96fe-1a63-e053-0824d011072a)
+    ///   - privateKeyID: Your private key ID from App Store Connect (Ex: 2X9R4HXF34). Will be inferred from `privateKeyURL` if nil.
+    ///   - privateKeyURL: A file URL that references the path to your private key file.
+    public init(issuerID: String, privateKeyID: String? = nil, privateKeyURL: URL) throws {
+        self.issuerID = issuerID
+        if let privateKeyID = privateKeyID {
+            self.privateKeyID = privateKeyID
+        } else {
+            let filename = privateKeyURL.deletingPathExtension().lastPathComponent
+            self.privateKeyID = String(filename.suffix(10))
+        }
+        do {
+            let pemEncodedPrivateKey = try String(contentsOf: privateKeyURL)
+            self.privateKey = try JWT.PrivateKey(pemRepresentation: pemEncodedPrivateKey)
+        } catch {
+            throw JWT.Error.invalidPrivateKey
+        }
+    }
 }
 
 /// Provides access to all API Methods. Can be used to perform API requests.


### PR DESCRIPTION
As per the [documentation](https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api):
>Keep your API keys secure and private. Don’t share your keys, store keys in a code repository, or include keys in client-side code.